### PR TITLE
fix: test

### DIFF
--- a/src/services/groups/update-group.test.ts
+++ b/src/services/groups/update-group.test.ts
@@ -1,0 +1,222 @@
+import { makeFakeGroupMember } from '@/data/group-members/__test-utils__/make-fake-group-member';
+import { makeFakeGroup } from '@/data/groups/__test-utils__/make-fake-group';
+import { mockDbClient } from '@/db/__test-utils__/mock-db-client';
+import { GroupMemberRole, GroupSplitType } from '@/db/types';
+import { mockSession } from '@/middlewares/__test-utils__/openapi-hono';
+import { BadRequestError, ForbiddenError } from '@/utils/errors';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateGroupService } from './update-group';
+
+const mockDependencies = {
+  getGroupMemberData: vi.fn(),
+  updateGroupData: vi.fn(),
+  updateGroupMemberData: vi.fn(),
+};
+
+const mockGroup = makeFakeGroup({
+  name: 'Original Group Name',
+  description: 'Original Description',
+  tag: 'original-tag',
+  split_type: GroupSplitType.EQUAL,
+});
+
+const mockOwnerMember = makeFakeGroupMember({
+  group_id: mockGroup.id,
+  user_id: mockSession.accountId,
+  role: GroupMemberRole.OWNER,
+});
+
+const mockMember = makeFakeGroupMember({
+  id: 'member-id-1',
+  group_id: mockGroup.id,
+  user_id: 'user-id-1',
+  role: GroupMemberRole.MEMBER,
+  percentage_share: 50,
+});
+
+const mockUpdatedMember = {
+  ...mockMember,
+  percentage_share: 60,
+};
+
+describe('updateGroupService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully update a group and its members', async () => {
+    const payload = {
+      session: mockSession,
+      groupId: mockGroup.id,
+      name: 'Updated Group Name',
+      description: 'Updated Description',
+      tag: 'updated-tag',
+      split_type: GroupSplitType.PERCENTAGE,
+      members: [
+        {
+          id: mockMember.id,
+          percentage_share: 60,
+        },
+      ],
+    };
+
+    mockDependencies.getGroupMemberData.mockResolvedValue(mockOwnerMember);
+    mockDependencies.updateGroupData.mockResolvedValue({
+      ...mockGroup,
+      name: payload.name,
+      description: payload.description,
+      tag: payload.tag,
+      split_type: payload.split_type,
+    });
+    mockDependencies.updateGroupMemberData.mockResolvedValue(mockUpdatedMember);
+
+    const result = await updateGroupService({
+      dbClient: mockDbClient.dbClientTransaction,
+      payload,
+      dependencies: mockDependencies,
+    });
+
+    expect(mockDependencies.getGroupMemberData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      groupId: payload.groupId,
+      userId: payload.session.accountId,
+    });
+
+    expect(mockDependencies.updateGroupData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      id: payload.groupId,
+      values: {
+        name: payload.name,
+        description: payload.description,
+        tag: payload.tag,
+        split_type: payload.split_type,
+      },
+    });
+
+    expect(mockDependencies.updateGroupMemberData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      id: mockMember.id,
+      groupId: payload.groupId,
+      values: {
+        placeholder_assignee_name: undefined,
+        role: undefined,
+        user_id: undefined,
+        percentage_share: 60,
+        exact_share: undefined,
+      },
+    });
+
+    expect(result).toEqual({
+      groupId: payload.groupId,
+      updatedMembers: [mockUpdatedMember],
+    });
+  });
+
+  it('should successfully update only group details without members', async () => {
+    const payload = {
+      session: mockSession,
+      groupId: mockGroup.id,
+      name: 'Updated Group Name',
+      description: 'Updated Description',
+    };
+
+    mockDependencies.getGroupMemberData.mockResolvedValue(mockOwnerMember);
+    mockDependencies.updateGroupData.mockResolvedValue({
+      ...mockGroup,
+      name: payload.name,
+      description: payload.description,
+    });
+
+    const result = await updateGroupService({
+      dbClient: mockDbClient.dbClientTransaction,
+      payload,
+      dependencies: mockDependencies,
+    });
+
+    expect(mockDependencies.getGroupMemberData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      groupId: payload.groupId,
+      userId: payload.session.accountId,
+    });
+
+    expect(mockDependencies.updateGroupData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      id: payload.groupId,
+      values: {
+        name: payload.name,
+        description: payload.description,
+        tag: undefined,
+        split_type: undefined,
+      },
+    });
+
+    expect(mockDependencies.updateGroupMemberData).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      groupId: payload.groupId,
+      updatedMembers: [],
+    });
+  });
+
+  it('should throw BadRequestError when members array is empty', async () => {
+    const payload = {
+      session: mockSession,
+      groupId: mockGroup.id,
+      members: [],
+    };
+
+    mockDependencies.getGroupMemberData.mockResolvedValue(mockOwnerMember);
+
+    await expect(
+      updateGroupService({
+        dbClient: mockDbClient.dbClientTransaction,
+        payload,
+        dependencies: mockDependencies,
+      })
+    ).rejects.toThrow(new BadRequestError('You must update at least one member of a group.'));
+
+    expect(mockDependencies.getGroupMemberData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      groupId: payload.groupId,
+      userId: payload.session.accountId,
+    });
+
+    expect(mockDependencies.updateGroupData).not.toHaveBeenCalled();
+    expect(mockDependencies.updateGroupMemberData).not.toHaveBeenCalled();
+  });
+
+  it('should throw ForbiddenError when user is not authorized', async () => {
+    const regularMember = {
+      ...mockMember,
+      user_id: mockSession.accountId,
+      role: GroupMemberRole.MEMBER,
+    };
+
+    const payload = {
+      session: mockSession,
+      groupId: mockGroup.id,
+      name: 'Updated Group Name',
+    };
+
+    mockDependencies.getGroupMemberData.mockResolvedValue(regularMember);
+
+    await expect(
+      updateGroupService({
+        dbClient: mockDbClient.dbClientTransaction,
+        payload,
+        dependencies: mockDependencies,
+      })
+    ).rejects.toThrow(
+      new ForbiddenError('You are not authorized to update members of this group.')
+    );
+
+    expect(mockDependencies.getGroupMemberData).toHaveBeenCalledWith({
+      dbClient: mockDbClient.dbClient,
+      groupId: payload.groupId,
+      userId: payload.session.accountId,
+    });
+
+    expect(mockDependencies.updateGroupData).not.toHaveBeenCalled();
+    expect(mockDependencies.updateGroupMemberData).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/groups/update-group.ts
+++ b/src/services/groups/update-group.ts
@@ -53,7 +53,7 @@ export async function updateGroupService({
       throw new ForbiddenError('You are not authorized to update members of this group.');
     }
 
-    if (payload.members.length === 0) {
+    if (payload.members && !payload.members.length === 0) {
       throw new BadRequestError('You must update at least one member of a group.');
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes logic error in group member update validation

- Ensures correct validation for empty `members` array


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-group.ts</strong><dd><code>Fix validation logic for group member updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/groups/update-group.ts

<li>Corrects conditional check for empty <code>members</code> array in group update <br>service<br> <li> Prevents improper validation when updating group members


</details>


  </td>
  <td><a href="https://github.com/constROD/budget-group-api/pull/1/files#diff-30ec62994df85ef055bc81823954ca67126667a09388f10528713732426bbb96">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>